### PR TITLE
Fix bug that causes validateRequest to fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -403,7 +403,7 @@ class CashID {
       let missingFields = [];
 
       // Loop over the required metadata fields.
-      for (const metadataValue in parsedRequest['parameters']['required']) {
+      for (const metadataName in parsedRequest['parameters']['required']) {
         // If the field was required && missing from the response..
         if (
           metadataValue &&


### PR DESCRIPTION
Looks like a typo during conversion from the PHP Library.
The loop was iterating with a var named "metadataValue" where as should be "metadataName".